### PR TITLE
Potential fix for code scanning alert no. 1: Use of password hash with insufficient computational effort

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "remark-math": "^5.1.1",
     "swr": "^2.0.3",
     "use-clipboard-copy": "^0.2.0",
-    "use-constant": "^1.1.1"
+    "use-constant": "^1.1.1",
+    "bcrypt": "^5.1.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",

--- a/src/utils/protectedRouteHandler.ts
+++ b/src/utils/protectedRouteHandler.ts
@@ -1,12 +1,13 @@
-import sha256 from 'crypto-js/sha256'
+import bcrypt from 'bcrypt'
 import siteConfig from '../../config/site.config'
 
-// Hash password token with SHA256
+// Hash password token with bcrypt
 function encryptToken(token: string): string {
-  return sha256(token).toString()
+  const saltRounds = 10;
+  return bcrypt.hashSync(token, saltRounds);
 }
 
-// Fetch stored token from localStorage and encrypt with SHA256
+// Fetch stored token from localStorage and encrypt with bcrypt
 export function getStoredToken(path: string): string | null {
   const storedToken =
     typeof window !== 'undefined' ? JSON.parse(localStorage.getItem(matchProtectedRoute(path)) as string) : ''
@@ -15,7 +16,7 @@ export function getStoredToken(path: string): string | null {
 
 /**
  * Compares the hash of .password and od-protected-token header
- * @param odTokenHeader od-protected-token header (sha256 hashed token)
+ * @param odTokenHeader od-protected-token header (bcrypt hashed token)
  * @param dotPassword non-hashed .password file
  * @returns whether the two hashes are the same
  */
@@ -26,7 +27,7 @@ export function compareHashedToken({
   odTokenHeader: string
   dotPassword: string
 }): boolean {
-  return encryptToken(dotPassword.trim()) === odTokenHeader
+  return bcrypt.compareSync(dotPassword.trim(), odTokenHeader);
 }
 /**
  * Match the specified route against a list of predefined routes


### PR DESCRIPTION
Potential fix for [https://github.com/dekthaiinchina/onedrive-vercel-index/security/code-scanning/1](https://github.com/dekthaiinchina/onedrive-vercel-index/security/code-scanning/1)

To fix the problem, we need to replace the use of the `sha256` hashing algorithm with a more secure password hashing algorithm such as `bcrypt`. This will involve updating the `encryptToken` function to use `bcrypt` for hashing tokens. Additionally, we need to ensure that the `compareHashedToken` function correctly compares the hashed tokens using `bcrypt`.

1. Install the `bcrypt` library if it is not already installed.
2. Update the `encryptToken` function to use `bcrypt` for hashing tokens.
3. Update the `compareHashedToken` function to use `bcrypt` for comparing hashed tokens.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
